### PR TITLE
sync_read: deprecated

### DIFF
--- a/Unraid_Scripts/rclone_mount.sh
+++ b/Unraid_Scripts/rclone_mount.sh
@@ -114,7 +114,7 @@ start() {
 
     if ! is_mounted $MOUNT_POINT_MERGERFS; then
         echo -e "\033[32mRunning mergerfs...\033[0m"
-        $MERGERFS_BIN $MOUNT_POINT:$MOUNT_POINT_LOCAL $MOUNT_POINT_MERGERFS -o defaults,sync_read,allow_other,category.action=all,category.create=ff
+        $MERGERFS_BIN $MOUNT_POINT:$MOUNT_POINT_LOCAL $MOUNT_POINT_MERGERFS -o defaults,async_read=false,allow_other,category.action=all,category.create=ff
     fi
 
     start_docker_containers

--- a/Unraid_Scripts/rclone_mount.sh
+++ b/Unraid_Scripts/rclone_mount.sh
@@ -114,7 +114,7 @@ start() {
 
     if ! is_mounted $MOUNT_POINT_MERGERFS; then
         echo -e "\033[32mRunning mergerfs...\033[0m"
-        $MERGERFS_BIN $MOUNT_POINT:$MOUNT_POINT_LOCAL $MOUNT_POINT_MERGERFS -o defaults,sync_read,allow_other,category.action=all,category.create=ff
+        $MERGERFS_BIN $MOUNT_POINT:$MOUNT_POINT_LOCAL $MOUNT_POINT_MERGERFS -o defaults,async_read=false,category.action=all,category.create=ff
     fi
 
     start_docker_containers

--- a/Unraid_Scripts/rclone_mount.sh
+++ b/Unraid_Scripts/rclone_mount.sh
@@ -114,7 +114,7 @@ start() {
 
     if ! is_mounted $MOUNT_POINT_MERGERFS; then
         echo -e "\033[32mRunning mergerfs...\033[0m"
-        $MERGERFS_BIN $MOUNT_POINT:$MOUNT_POINT_LOCAL $MOUNT_POINT_MERGERFS -o defaults,async_read=false,category.action=all,category.create=ff
+        $MERGERFS_BIN $MOUNT_POINT:$MOUNT_POINT_LOCAL $MOUNT_POINT_MERGERFS -o defaults,sync_read,allow_other,category.action=all,category.create=ff
     fi
 
     start_docker_containers

--- a/Unraid_Scripts/rclone_multimount.sh
+++ b/Unraid_Scripts/rclone_multimount.sh
@@ -151,7 +151,7 @@ start() {
     # Start mergerfs
     if ! is_mounted $MOUNT_POINT_MERGERFS; then
         echo -e "\033[32mRunning mergerfs...\033[0m"
-        $MERGERFS_BIN $MOUNT_POINT_REMOTE1:$MOUNT_POINT_REMOTE2:$MOUNT_POINT_LOCAL $MOUNT_POINT_MERGERFS -o defaults,sync_read,allow_other,category.action=all,category.create=ff
+        $MERGERFS_BIN $MOUNT_POINT_REMOTE1:$MOUNT_POINT_REMOTE2:$MOUNT_POINT_LOCAL $MOUNT_POINT_MERGERFS -o defaults,sync_read=false,allow_other,category.action=all,category.create=ff
     fi
 
     # Start Docker containers

--- a/Unraid_Scripts/rclone_multimount.sh
+++ b/Unraid_Scripts/rclone_multimount.sh
@@ -151,7 +151,7 @@ start() {
     # Start mergerfs
     if ! is_mounted $MOUNT_POINT_MERGERFS; then
         echo -e "\033[32mRunning mergerfs...\033[0m"
-        $MERGERFS_BIN $MOUNT_POINT_REMOTE1:$MOUNT_POINT_REMOTE2:$MOUNT_POINT_LOCAL $MOUNT_POINT_MERGERFS -o defaults,sync_read=false,allow_other,category.action=all,category.create=ff
+        $MERGERFS_BIN $MOUNT_POINT_REMOTE1:$MOUNT_POINT_REMOTE2:$MOUNT_POINT_LOCAL $MOUNT_POINT_MERGERFS -o defaults,sync_read,allow_other,category.action=all,category.create=ff
     fi
 
     # Start Docker containers

--- a/Unraid_Scripts/rclone_multimount.sh
+++ b/Unraid_Scripts/rclone_multimount.sh
@@ -151,7 +151,7 @@ start() {
     # Start mergerfs
     if ! is_mounted $MOUNT_POINT_MERGERFS; then
         echo -e "\033[32mRunning mergerfs...\033[0m"
-        $MERGERFS_BIN $MOUNT_POINT_REMOTE1:$MOUNT_POINT_REMOTE2:$MOUNT_POINT_LOCAL $MOUNT_POINT_MERGERFS -o defaults,sync_read,allow_other,category.action=all,category.create=ff
+        $MERGERFS_BIN $MOUNT_POINT_REMOTE1:$MOUNT_POINT_REMOTE2:$MOUNT_POINT_LOCAL $MOUNT_POINT_MERGERFS -o defaults,async_read=false,allow_other,category.action=all,category.create=ff
     fi
 
     # Start Docker containers


### PR DESCRIPTION
As per https://github.com/trapexit/mergerfs

> - sync_read: deprecated - Perform reads synchronously. Use async_read=false instead.